### PR TITLE
Change the if/else for regex,prefix,postfix to an if statement

### DIFF
--- a/list-card.js
+++ b/list-card.js
@@ -160,9 +160,11 @@ class ListCard extends HTMLElement {
 
                       if (columns[column].hasOwnProperty('regex')) {
                         newText = new RegExp(columns[column].regex).exec(feed[entry][columns[column].field]);
-                      } else if (columns[column].hasOwnProperty('prefix')) {
+                      } 
+                      if (columns[column].hasOwnProperty('prefix')) {
                         newText = columns[column].prefix + newText;
-                      } else if (columns[column].hasOwnProperty('postfix')) {
+                      } 
+                      if (columns[column].hasOwnProperty('postfix')) {
                         newText += columns[column].postfix;
                       }
 


### PR DESCRIPTION
Change the if/else for regex,prefix,postfix to an if statement so they may all be used.

I am pulling down the list of new blu-ray releases from
https://www.blu-ray.com/rss/newreleasesfeed.xml
which does not include an image url, so I needed to isolate the movie ID, then do a prefix and postfix to build an img tag to have it shown:

> ### Blue Ray Movie Releases ###
>       - type: custom:list-card
>         entity: sensor.blu_ray_releases
>         title: Blu-Ray Releases
>         columns:
>           - title: ''
>             field: link
>             regex: \d+(?=\/)
>             prefix: '<img src="https://images3.static-bluray.com/movies/covers/'
>             postfix: '_small.jpg" />'
>           - title: Title
>             field: title
>             add_link: link
>             style:
>               - white-space: nowrap

![image](https://user-images.githubusercontent.com/7246759/60989745-50ad9900-a30c-11e9-8f52-2d771fa1b6c0.png)

