### PR TITLE
add support for fields containing icon string

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ From left to right: [feedparser](https://github.com/custom-components/sensor.fee
 | title | string | **Required** | Column header to display.
 | field | string | **Required** | key value of the entity that you wish to display.
 | add_link | string | **Optional** | key value of entity that has the link property to use.
-| type | string | **Optional** | options are `image`. Default is `None`. **Only set this for images, otherwise leave blank**
+| type | string | **Optional** | options are `image` and `icon`. Default is `None`. **Only set this for images or icons, otherwise leave blank**
 | style | object | **Optional** | CSS styles to apply to this column.
 | regex | string | **Optional** | Regex string to apply to field.
 | prefix | string | **Optional** | String to prefix to field.

--- a/list-card.js
+++ b/list-card.js
@@ -151,6 +151,8 @@ class ListCard extends HTMLElement {
                           } else {
                             card_content += `<img src="${feed[entry][columns[column].field]}" width="70" height="90">`;
                           }
+                      } else if (columns[column].type === 'icon') {
+                          card_content += `<ha-icon class="column-${columns[column].field}" icon=${feed[entry][columns[column].field]}></ha-icon>`;
                       }
                       // else if (columns[column].type === 'button') {
                       //   card_content += `<paper-button raised>${feed[entry][columns[column].button_text]}</paper-button>`;


### PR DESCRIPTION
add icon as a possible field type to go along with images. e.g. if field contains "mdi:car" it will display the car icon in that cell.