### PR TITLE
make regex unicode compatible

### DIFF
--- a/list-card.js
+++ b/list-card.js
@@ -172,7 +172,7 @@ class ListCard extends HTMLElement {
                       let newText = feed[entry][columns[column].field];
 
                       if (columns[column].hasOwnProperty('regex')) {
-                        newText = new RegExp(columns[column].regex).exec(feed[entry][columns[column].field]);
+                        newText = new RegExp(columns[column].regex, 'u').exec(feed[entry][columns[column].field]);
                       } 
                       if (columns[column].hasOwnProperty('prefix')) {
                         newText = columns[column].prefix + newText;


### PR DESCRIPTION
see https://gist.github.com/jakub-g/e580331ce7363b831d4273fb2fded4d9

so that e.g. 

```
field: day
regex: \p{Letter}+
```

will match "Måndag" in the field