### PR TITLE
Added Folder Integration Support and hass action support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+Additions submitted to @iantrich via pull-request.
+
+Switched from a table to grid view for better styling within the boundaries of the card (often as a table it was extending beyond the card).
+
+Added specific details for the folder integration usage, specifically when the feed_attribute is file_list it automatically creates the following columns: path, name, filename, fullpath, and ext.
+Path is just the path to the file not including the filename (e.g. '/config/www/media/files/')
+Name is the filename including extension or if the name matches the format YYYYMMDDHHmmSS.* it will translate it to human readable date/time in English. (e.g. 'snapshot.jpg or 'Mar 14, 2024, 3:12PM')
+filename is the filename including extension (e.g. 'snapshot.jpg')
+ext is just the extension (e.g. 'jpg')
+
+the add_link will work for any file in your folder integration that is in the www directory. simply add it to your column and it will work. By default add_link is included if no columns are specified.
+
+Actions added for specifically call-service, navigate, and fire-dom-event (part of call service). Any other action would be refused. It would be trivial to add such action if a use case could be made. Regular rules apply for each of these. Anything you include after action is sent to the action and is not part of this card's code but part of the HA built in hass-action code.
+
+Added ability to copy/paste data. Be aware the data updates at the frequency of your sensor so an attempt to "copy" that data might take more than one try if a sensor updates.
+
+Added ability to sort the feed. Use the following in the config at the base.
+sort:
+value: fieldname
+reverse: true (Defaults to false)
+
+
 # List Card by [@iantrich](https://www.github.com/iantrich)
 
 This card for [Lovelace](https://www.home-assistant.io/lovelace) on [Home Assistant](https://www.home-assistant.io/) that gives you a table generated with data from the [feedparser custom component](https://github.com/custom-components/sensor.feedparser) or any other sensor that provides data as a list of attributes.

--- a/list-card.js
+++ b/list-card.js
@@ -1,4 +1,4 @@
-console.log(`%clist-card\n%cVersion: ${'0.1.5'}`, 'color: #EED202; font-weight: bold;background-color: black;', '');
+console.log(`%clist-card\n%cVersion: ${'0.1.6'}`, 'color: #EED202; font-weight: bold;background-color: black;', '');
 
 class ListCard extends HTMLElement {
 
@@ -139,7 +139,7 @@ class ListCard extends HTMLElement {
       const root = this.shadowRoot;
       const card = root.lastChild;
 
-      if (hass.states[config.entity]) {
+      if (hass && hass.states[config.entity]) {
         const oldFeed = config.feed_attribute ? hass.states[config.entity].attributes[config.feed_attribute] : hass.states[config.entity].attributes;
         const feed = config.feed_attribute && config.feed_attribute == "file_list" ? this.transformFeed(oldFeed) : oldFeed;
 

--- a/list-card.js
+++ b/list-card.js
@@ -1,4 +1,4 @@
-console.log(`%clist-card\n%cVersion: ${'0.1.3'}`, 'color: #EED202; font-weight: bold;', '');
+console.log(`%clist-card\n%cVersion: ${'0.1.4'}`, 'color: #EED202; font-weight: bold;background-color: black;', '');
 
 class ListCard extends HTMLElement {
 
@@ -108,7 +108,7 @@ class ListCard extends HTMLElement {
 
       if (hass.states[config.entity]) {
         const oldFeed = config.feed_attribute ? hass.states[config.entity].attributes[config.feed_attribute] : hass.states[config.entity].attributes;
-
+        if (config.feed_attribute && config.feed_attribute == "file_list") {
         // if file_list is supplied as feed_attribute we will transform the data to be compatible with this component
         const transformedFeed = oldFeed.map(file => {
           const path = file.substring(0, file.lastIndexOf('/') + 1);
@@ -140,7 +140,7 @@ class ListCard extends HTMLElement {
             };
           }
         });
-        
+      }
         // turn feed into file columns if it's a file list, otherwise keep as needed
         const feed = config.feed_attribute && config.feed_attribute == "file_list" ? transformedFeed : oldFeed; 
 
@@ -167,13 +167,10 @@ class ListCard extends HTMLElement {
         
           // allow sorting on the fields
           // Sort the feed based on the specified column
-          console.log(config.sort);
           if (config.sort) {
-            console.log(config.sort.value);
             if (!config.sort.value) {
               throw new Error(`You need to specify a value to sort on`);
             }
-            console.log(config.sort.reverse);
             const sortField = config.sort.value;
             const isReverse = config.sort.reverse || false;
           

--- a/list-card.js
+++ b/list-card.js
@@ -1,4 +1,4 @@
-console.log(`%clist-card\n%cVersion: ${'0.0.1'}`, 'color: rebeccapurple; font-weight: bold;', '');
+console.log(`%clist-card\n%cVersion: ${'0.1.1'}`, 'color: #EED202; font-weight: bold;', '');
 
 class ListCard extends HTMLElement {
 
@@ -14,66 +14,77 @@ class ListCard extends HTMLElement {
 
       const root = this.shadowRoot;
       if (root.lastChild) root.removeChild(root.lastChild);
-
       const cardConfig = Object.assign({}, config);
+
+            // if no columns specified and it's a file list
+            if (config.feed_attribute && config.feed_attribute == "file_list" && (!cardConfig.columns || cardConfig.columns.length === 0)) {
+              cardConfig.columns = [
+                { title: "Path", field: "path" },
+                { title: "Name", field: "name" },
+                { title: "Filename", field: "filename" },
+                { title: "Full Path", field: "fullpath", add_link: "fullpath" },
+                { title: "Ext", field: "ext" }
+              ];
+            }
+      
       const columns = cardConfig.columns;
       const card = document.createElement('ha-card');
       const content = document.createElement('div');
       const style = document.createElement('style');
       style.textContent = `
             ha-card {
-              /* sample css */
-            }
-            table {
               width: 100%;
-              padding: 0 16px 16px 16px;
             }
-            thead th {
-              text-align: left;
-            }
-            tbody tr:nth-child(odd) {
-              background-color: var(--paper-card-background-color);
-            }
-            tbody tr:nth-child(even) {
-              background-color: var(--secondary-background-color);
-            }
-            .button {
-              overflow: auto;
+            
+            .grid-container {
+              display: grid;
+              grid-template-columns: repeat(${columns.length}, minmax(100px, 1fr));   
+              gap: 8px;
               padding: 16px;
+              overflow-y:auto;
+              max-height: 300px;
+            }          
+            .grid-row {
+                display: contents;
+            }        
+            .grid-header {
+              font-weight: bold;
+              text-align: center; /* Center the header text */
+            }           
+            .grid-cell {
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
             }
-            paper-button {
-              float: right;
-            }
-            td a {
-              color: var(--primary-text-color);
-              text-decoration-line: none;
-              font-weight: normal;
+            .actionable {
+              cursor: pointer;
             }
           `;
 
-      // Go through columns and add CSS sytling to each column that is defined
+      // Go through columns and add CSS styling to each column that is defined
       if (columns) {
         for (let column in columns) {
-          if (columns.hasOwnProperty(column) && columns[column].hasOwnProperty('style')) {
-            let styles = columns[column]['style'];
+          if (columns.hasOwnProperty(column) && columns[column]) {
+            if (columns[column]['style']) {
+              let styles = columns[column]['style'];
 
-            style.textContent += `
-              .${columns[column].field} {`
+              style.textContent += `
+                .${columns[column].field} {`;
 
-            for (let index in styles) {
-              if (styles.hasOwnProperty(index)) {
-                for (let s in styles[index]) {
-                  style.textContent += `
-                  ${s}: ${styles[index][s]};`;
+              for (let index in styles) {
+                if (styles.hasOwnProperty(index)) {
+                  for (let s in styles[index]) {
+                    style.textContent += `
+                    ${s}: ${styles[index][s]};`;
+                  }
                 }
               }
-            }
 
-            style.textContent += `}`;
+              style.textContent += `}`;
+            }
           }
         }
       }
-
       content.id = "container";
       cardConfig.title ? card.header = cardConfig.title : null;
       card.appendChild(content);
@@ -88,128 +99,255 @@ class ListCard extends HTMLElement {
       const card = root.lastChild;
 
       if (hass.states[config.entity]) {
-        const feed = config.feed_attribute ? hass.states[config.entity].attributes[config.feed_attribute] : hass.states[config.entity].attributes;
+        const oldFeed = config.feed_attribute ? hass.states[config.entity].attributes[config.feed_attribute] : hass.states[config.entity].attributes;
+
+        // if file_list is supplied as feed_attribute we will transform the data to be compatible with this component
+        const transformedFeed = oldFeed.map(file => {
+          const path = file.substring(0, file.lastIndexOf('/') + 1);
+          const filenameParts = file.split('/').pop().split('.');
+          const filename = filenameParts[0];
+          const extension = filenameParts[filenameParts.length - 1];
+          
+          // Check if the filename matches the expected format (YYYYMMDDHHmmSS)
+          const filenameFormat = /^\d{14}$/;
+          
+          if (filenameFormat.test(filename)) {
+            const fileDate = new Date(filename.slice(0, 4) + '-' + filename.slice(4, 6) + '-' + filename.slice(6, 8) + 'T' + filename.slice(8, 10) + ':' + filename.slice(10, 12) + ':' + filename.slice(12));
+            const formattedDate = fileDate.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', hour12: true });
+            
+            return {
+              path: path,
+              name: formattedDate,
+              filename: filename + "." + extension,
+              fullpath: path + filename + "." + extension,
+              ext: extension
+            };
+          } else {
+            return {
+              path: path,
+              name: filename,
+              filename: filename + "." + extension,
+              fullpath: path + filename + "." + extension,
+              ext: extension
+            };
+          }
+        });
+        
+        // turn feed into file columns if it's a file list, otherwise keep as needed
+        const feed = config.feed_attribute && config.feed_attribute == "file_list" ? transformedFeed : oldFeed; 
+
         const columns = config.columns;
         this.style.display = 'block';
         const rowLimit = config.row_limit ? config.row_limit : Object.keys(feed).length;
         let rows = 0;
 
         if (feed !== undefined && Object.keys(feed).length > 0) {
-          let card_content = '<table><thread><tr>';
-
-          if (!columns) {
-            card_content += `<tr>`;
-
-            for (let column in feed[0]) {
-              if (feed[0].hasOwnProperty(column)) {
-                card_content += `<th>${feed[0][column]}</th>`;
-              }
-            }
-          } else {
+          let card_content = '<div class="grid-container">';
+        
+          // Generate the header row
+          if (columns) {
+            card_content += '<div class="grid-row">';
             for (let column in columns) {
               if (columns.hasOwnProperty(column)) {
-                card_content += `<th class=${columns[column].field}>${columns[column].title}</th>`;
+                card_content += `<div class="grid-cell grid-header ${columns[column].field}">${columns[column].title}</div>`;
               }
             }
+            card_content += '</div>';
           }
-
-          card_content += `</tr></thead><tbody>`;
-
+        
+          // Generate the data rows
           for (let entry in feed) {
             if (rows >= rowLimit) break;
-
+        
             if (feed.hasOwnProperty(entry)) {
-              if (!columns) {
-                for (let field in feed[entry]) {
-                  if (feed[entry].hasOwnProperty(field)) {
-                    card_content += `<td>${feed[entry][field]}</td>`;
-                  }
-                }
-              } else {
-                let has_field = true;
-
+              let has_field = true;
+        
+              if (columns) {
                 for (let column in columns) {
                   if (!feed[entry].hasOwnProperty(columns[column].field)) {
                     has_field = false;
                     break;
                   }
                 }
-
-                if (!has_field) continue;
-                card_content += `<tr>`;
-
+              }
+        
+              if (!has_field) continue;     
+              card_content += '<div class="grid-row">';
+              if (columns) {
                 for (let column in columns) {
-                  if (columns.hasOwnProperty(column)) {
-                    card_content += `<td class=${columns[column].field}>`;
-
+                  if (columns.hasOwnProperty(column) && feed[entry].hasOwnProperty(columns[column].field)) {
+                    const tapAction = columns[column].tap_action;
+                    const holdAction = columns[column].hold_action;
+                    const doubleTapAction = columns[column].double_tap_action;
+                    
+                    // added field for row data so we can retrieve it on action call
+                    card_content += `<div class="grid-cell ${columns[column].field}${tapAction || holdAction || doubleTapAction ? ' actionable' : ''}" 
+                    ${tapAction || holdAction || doubleTapAction ? `data-listcardID='${JSON.stringify(feed[entry])}'` : ''}
+                    ${tapAction ? `data-tap-action='${JSON.stringify(tapAction)}'` : ''}
+                    ${holdAction ? `data-hold-action='${JSON.stringify(holdAction)}'` : ''}
+                    ${doubleTapAction ? `data-double-tap-action='${JSON.stringify(doubleTapAction)}'` : ''}>`;
+                                                                           
+                    // added .replace('config/www','local') so you can open files in the ha www folder with add_link
                     if (columns[column].hasOwnProperty('add_link')) {
-                      card_content +=  `<a href="${feed[entry][columns[column].add_link]}" target='_blank'>`;
+                      card_content += `<a href="${feed[entry][columns[column].add_link].replace('config/www','local')}" target='_blank'>`;
                     }
-
+        
                     if (columns[column].hasOwnProperty('type')) {
                       if (columns[column].type === 'image') {
-                        if (columns[column].hasOwnProperty('width')) {
-                          var image_width = columns[column].width;
-                        } else {
-                          var image_width = 70;
-                        }
-                        if (columns[column].hasOwnProperty('height')) {
-                          var image_height = columns[column].height;
-                        } else {
-                          var image_height = 90;
-                        }
-                        if (feed[entry][columns[column].field][0].hasOwnProperty('url')) {
-                            var url = feed[entry][columns[column].field][0].url
-                        } else {
-                          var url = feed[entry][columns[column].field]
-                        }
-                          card_content += `<img id="image" src="${url}" width="${image_width}" height="${image_height}">`;
+                        let image_width = columns[column].width || 70;
+                        let image_height = columns[column].height || 90;
+                        let url = feed[entry][columns[column].field][0]?.url || feed[entry][columns[column].field];
+                        card_content += `<img id="image" src="${url}" width="${image_width}" height="${image_height}">`;
                       } else if (columns[column].type === 'icon') {
                         card_content += `<ha-icon class="column-${columns[column].field}" icon=${feed[entry][columns[column].field]}></ha-icon>`;
                       }
-                      // else if (columns[column].type === 'button') {
-                      //   card_content += `<paper-button raised>${feed[entry][columns[column].button_text]}</paper-button>`;
-                      // }
                     } else {
                       let newText = feed[entry][columns[column].field];
-
+        
                       if (columns[column].hasOwnProperty('regex')) {
                         newText = new RegExp(columns[column].regex, 'u').exec(feed[entry][columns[column].field]);
-                      } 
+                      }
                       if (columns[column].hasOwnProperty('prefix')) {
                         newText = columns[column].prefix + newText;
-                      } 
+                      }
                       if (columns[column].hasOwnProperty('postfix')) {
                         newText += columns[column].postfix;
                       }
-
+        
                       card_content += `${newText}`;
                     }
-
+        
                     if (columns[column].hasOwnProperty('add_link')) {
-                      card_content +=  `</a>`;
+                      card_content += '</a>';
                     }
-
-                    card_content += `</td>`;
+        
+                    card_content += '</div>';
                   }
                 }
               }
-
-              card_content += `</tr>`;
+              card_content += '</div>';        
               ++rows;
             }
           }
-
+        
           root.lastChild.hass = hass;
-          card_content += `</tbody></table>`;
+          card_content += '</div>';
           root.getElementById('container').innerHTML = card_content;
+          
+
+          // Add event listeners for tap_action, hold_action, and double_tap_action
+          const cells = root.querySelectorAll('.grid-cell');
+          cells.forEach(cell => {
+            const tapAction = cell.getAttribute('data-tap-action');
+            const holdAction = cell.getAttribute('data-hold-action');
+            const doubleTapAction = cell.getAttribute('data-double-tap-action');
+            const listcardID = cell.getAttribute('data-listcardID');
+
+            if (tapAction) {
+              cell.addEventListener('click', () => {
+                this.handleAction(hass, JSON.parse(tapAction), listcardID);
+              });
+            }
+
+            if (holdAction) {
+              let timer = null;
+              cell.addEventListener('touchstart', () => {
+                timer = setTimeout(() => {
+                  this.handleAction(hass, JSON.parse(holdAction), listcardID);
+                }, 500);
+              });
+              cell.addEventListener('touchend', () => {
+                clearTimeout(timer);
+              });
+            }
+
+            if (doubleTapAction) {
+              cell.addEventListener('dblclick', () => {
+                this.handleAction(hass, JSON.parse(doubleTapAction), listcardID);
+              });
+            }
+          });
+
         } else {
           this.style.display = 'none';
         }
       } else {
         this.style.display = 'none';
       }
-    }
+    }     
+
+
+                        // added logic to allow users to send '[[fieldname]]' in tap_action events
+                        handleAction = (hass, action, listcardID) => {
+                          if (action && action.action) {
+                            // Replace placeholders in action data
+                            const row = JSON.parse(listcardID);
+                            action = this.replacePlaceholdersInAction(action, row); 
+                    
+                            switch (action.action) {
+                              case 'call-service':
+                              case 'navigate':
+                              case 'fire-dom-event':
+
+                              const actionConfig = {
+                                tap_action: action
+                                };
+                                
+                                const event = new Event("hass-action", {
+                                  bubbles: true,
+                                  composed: true,
+                                });
+                                event.detail = {
+                                  config: actionConfig,
+                                  action: "tap",
+                                };
+                                this.dispatchEvent(event);
+                                break;
+                              default:
+                                console.warn('Unsupported action type:', action.action);
+                            }
+                          } else {
+                            console.warn('Invalid action object:', action);
+                          }
+                        }
+                    
+                        replacePlaceholdersInAction = (action, row) => {
+                          // Recursively traverse the action object
+                          const traverse = (obj) => {
+                              for (const key in obj) {
+                                  if (typeof obj[key] === 'string') {
+                                      // Check if the value is a string
+                                      let replacedString = obj[key];
+                                      const placeholders = replacedString.match(/\[\[(.*?)\]\]/g);
+                                      if (placeholders) {
+                                          // Replace each placeholder with the actual value from data
+                                          placeholders.forEach(placeholder => {
+                                              const field = placeholder.substring(2, placeholder.length - 2); // Extract the field name
+                                              // Find the row with matching listcardID
+                                              // Check if the field exists in the row
+                                              if (row && row.hasOwnProperty(field)) {
+                                                  // Replace the placeholder with the field data
+                                                  replacedString = replacedString.replace(placeholder, row[field]);
+                                              } else {
+                                                  // Throw an error if the field doesn't match any of ours
+                                                  throw new Error(`Invalid field '${field}' specified in action: ${JSON.stringify(action)}`);
+                                              }
+                                          });
+                                          // Update the value of the object key with the replaced string
+                                          obj[key] = replacedString;
+                                      }
+                                  } else if (typeof obj[key] === 'object') {
+                                      // If the value is an object, recursively traverse it
+                                      traverse(obj[key]);
+                                  }
+                              }
+                          };
+                      
+                          // Start traversal from the top-level action object
+                          traverse(action);
+                          return action;
+                      }
+                      
 
     getCardSize() {
       return 1;
@@ -223,5 +361,5 @@ window.customCards.push({
   type: "list-card",
   name: "List Card",
   preview: false,
-  description: "The List Card generate table with data from sensor that provides data as a list of attributes."
+  description: "The List Card generate a grid with data from sensor that provides data as a list of attributes. It will also handle the file_list attribute from the folder integration."
 });

--- a/list-card.js
+++ b/list-card.js
@@ -1,4 +1,4 @@
-console.log(`%clist-card\n%cVersion: ${'0.1.1'}`, 'color: #EED202; font-weight: bold;', '');
+console.log(`%clist-card\n%cVersion: ${'0.1.3'}`, 'color: #EED202; font-weight: bold;', '');
 
 class ListCard extends HTMLElement {
 
@@ -144,6 +144,8 @@ class ListCard extends HTMLElement {
         // turn feed into file columns if it's a file list, otherwise keep as needed
         const feed = config.feed_attribute && config.feed_attribute == "file_list" ? transformedFeed : oldFeed; 
 
+
+
         const columns = config.columns;
         this.style.display = 'block';
         const rowLimit = config.row_limit ? config.row_limit : Object.keys(feed).length;
@@ -163,6 +165,32 @@ class ListCard extends HTMLElement {
             card_content += '</div>';
           }
         
+          // allow sorting on the fields
+          // Sort the feed based on the specified column
+          console.log(config.sort);
+          if (config.sort) {
+            console.log(config.sort.value);
+            if (!config.sort.value) {
+              throw new Error(`You need to specify a value to sort on`);
+            }
+            console.log(config.sort.reverse);
+            const sortField = config.sort.value;
+            const isReverse = config.sort.reverse || false;
+          
+            feed.sort((a, b) => {
+              const valueA = a[sortField];
+              const valueB = b[sortField];
+
+              if (valueA < valueB) {
+                return isReverse ? 1 : -1;
+              }
+              if (valueA > valueB) {
+                return isReverse ? -1 : 1;
+              }
+              return 0;
+            });
+          }
+
           // Generate the data rows
           for (let entry in feed) {
             if (rows >= rowLimit) break;

--- a/list-card.js
+++ b/list-card.js
@@ -16,7 +16,7 @@ class ListCard extends HTMLElement {
       if (root.lastChild) root.removeChild(root.lastChild);
       const cardConfig = Object.assign({}, config);
 
-            // if no columns specified and it's a file list
+            // if no columns are specifically specified and it's a file_list from the folder integration
             if (config.feed_attribute && config.feed_attribute == "file_list" && (!cardConfig.columns || cardConfig.columns.length === 0)) {
               cardConfig.columns = [
                 { title: "Path", field: "path" },
@@ -61,7 +61,8 @@ class ListCard extends HTMLElement {
             }
           `;
 
-      // Go through columns and add CSS styling to each column that is defined
+      // Go through columns and add CSS styling to each column that is defined with the style tag, 
+      // the css class will be the field name of the column.
       if (columns) {
         for (let column in columns) {
           if (columns.hasOwnProperty(column) && columns[column]) {
@@ -85,11 +86,14 @@ class ListCard extends HTMLElement {
           }
         }
       }
+
       content.id = "container";
       cardConfig.title ? card.header = cardConfig.title : null;
+
       card.appendChild(content);
       card.appendChild(style);
       root.appendChild(card);
+      
       this._config = cardConfig;
     }
 

--- a/list-card.js
+++ b/list-card.js
@@ -55,6 +55,10 @@ class ListCard extends HTMLElement {
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
+              user-select: text;
+              -webkit-user-select: text;
+              -moz-user-select: text;
+              -ms-user-select: text;
             }
             .actionable {
               cursor: pointer;
@@ -93,7 +97,7 @@ class ListCard extends HTMLElement {
       card.appendChild(content);
       card.appendChild(style);
       root.appendChild(card);
-      
+
       this._config = cardConfig;
     }
 
@@ -218,7 +222,7 @@ class ListCard extends HTMLElement {
                         newText += columns[column].postfix;
                       }
         
-                      card_content += `${newText}`;
+                      card_content += `<span>${newText}</span>`;
                     }
         
                     if (columns[column].hasOwnProperty('add_link')) {


### PR DESCRIPTION
Switched from a table to grid view for better styling within the boundaries of the card (often as a table it was extending beyond the card).

Added specific details for the folder integration usage, specifically when the feed_attribute is file_list it automatically creates the following columns: path, name, filename, fullpath, and ext. 
Path is just the path to the file not including the filename (e.g. '/config/www/media/files/')
Name is the filename including extension _or_ if the name matches the format YYYYMMDDHHmmSS.* it will translate it to human readable date/time in English.  (e.g. 'snapshot.jpg or 'Mar 14, 2024, 3:12PM')
filename is the filename including extension (e.g. 'snapshot.jpg')
ext is just the extension (e.g. 'jpg')

the add_link will work for any file in your folder integration that is in the www directory. simply add it to your column and it will work. By default add_link is included if no columns are specified.

Actions added for specifically call-service, navigate, and fire-dom-event (part of call service). Any other action would be refused. It would be trivial to add such action if a use case could be made. Regular rules apply for each of these. Anything you include after action is sent to the action and is not part of this card's code but part of the HA built in hass-action code. 

Added ability to copy/paste data.

Added ability to sort the feed. Use the following in the config at the base. 
sort:
  value: fieldname
  reverse: true (Defaults to false)